### PR TITLE
Add video test script and project roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,47 @@
-# embedded-object-detection-pi5
+# Embedded Object Detection on Raspberry Pi 5
+
+This project demonstrates how to run ONNX object detection models on a Raspberry Pi 5 using the **ONNX Runtime** C API.  The current code simply loads a model and verifies that the runtime is working, serving as a starting point for further development.
+
+## Requirements
+
+- C compiler with C11 support (e.g., GCC)
+- [CMake](https://cmake.org/) 3.10 or newer
+- Pre‑built ONNX Runtime library for aarch64.  By default the build expects it under:
+  `$HOME/onnxruntime_c/onnxruntime-linux-aarch64-1.17.3`
+- A trained ONNX model (placeholder path `model/model.onnx` is used in `main.c`)
+
+## Building
+
+1. Create a build directory and run CMake:
+   ```bash
+   mkdir build
+   cd build
+   cmake ..
+   make
+   ```
+2. Run the example program:
+   ```bash
+   ./detector
+   ```
+
+Adjust `CMakeLists.txt` or set the `ONNX_DIR` variable if your ONNX Runtime installation is in a different location.
+
+## Repository Layout
+
+- `main.c` – Program entry point that prints the ONNX Runtime version and attempts to load the model.
+- `src/onnx_utils.c` / `include/onnx_utils.h` – Helper functions to create an ONNX Runtime environment and session.
+- `CMakeLists.txt` – Build configuration linking against ONNX Runtime.
+
+The project is at an early stage and currently only tests that a model can be loaded.  Further object detection logic will be added in the future.
+
+## Next Steps
+
+Several features are planned as the project grows:
+
+- **Test video script** – `test_video.py` processes a video file or camera input and draws bounding boxes using a loaded ONNX model. Run it with:
+  ```bash
+  python3 test_video.py <video.mp4>
+  ```
+- **Optimized inference on the Pi 5** – Evaluate execution providers in ONNX Runtime, compare against TFLite and OpenCV DNN, and investigate leveraging the Raspberry Pi 5 NPU when available.
+- **Live camera detection** – Pass a camera index (e.g. `0`) to `test_video.py` to see detections from a connected camera.
+- **ROS2 integration** – Publish detection results from a ROS2 node and visualize them in RViz.

--- a/test_video.py
+++ b/test_video.py
@@ -1,0 +1,64 @@
+import argparse
+import cv2
+import numpy as np
+import onnxruntime as ort
+
+
+def draw_detections(frame, detections, score_thresh=0.4):
+    """Draw bounding boxes on the frame.
+    The model output is expected as Nx6: x1, y1, x2, y2, score, class."""
+    if detections is None:
+        return
+    for det in detections:
+        if len(det) < 6 or det[4] < score_thresh:
+            continue
+        x1, y1, x2, y2 = map(int, det[:4])
+        cls = int(det[5]) if len(det) > 5 else 0
+        cv2.rectangle(frame, (x1, y1), (x2, y2), (0, 255, 0), 2)
+        cv2.putText(frame, str(cls), (x1, y1 - 5), cv2.FONT_HERSHEY_SIMPLEX,
+                    0.5, (0, 255, 0), 1)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run object detection on a video file")
+    parser.add_argument("source", help="Path to video file or camera index")
+    parser.add_argument("--model", default="model/model.onnx", help="Path to ONNX model")
+    parser.add_argument("--score-thresh", type=float, default=0.4, help="Score threshold")
+    args = parser.parse_args()
+
+    try:
+        cam_index = int(args.source)
+        cap = cv2.VideoCapture(cam_index)
+    except ValueError:
+        cap = cv2.VideoCapture(args.source)
+
+    if not cap.isOpened():
+        print(f"Failed to open {args.source}")
+        return
+
+    session = ort.InferenceSession(args.model)
+    input_name = session.get_inputs()[0].name
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        img = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
+        img = cv2.resize(img, (640, 640))
+        img = img.transpose(2, 0, 1).astype(np.float32)
+        img = np.expand_dims(img, 0)
+
+        outputs = session.run(None, {input_name: img})
+        detections = outputs[0] if outputs else None
+        draw_detections(frame, detections, args.score_thresh)
+
+        cv2.imshow("detections", frame)
+        if cv2.waitKey(1) & 0xFF == 27:
+            break
+
+    cap.release()
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `test_video.py` to run inference on a video or camera feed
- outline next development steps in README

## Testing
- `cmake ..` (from `build` directory)
- `make` *(fails: onnxruntime_c_api.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_687ca03cea4083278887e63e7f986c65